### PR TITLE
Scix id support for the citation_helper service

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Start with
   
 and do a request from the command line like so
 
-	curl -H "Content-Type: application/json" -X POST -d '{"bibcodes":["1980ApJS...44..169S","1980ApJS...44..193S"]}' http://localhost:4000
+	curl -H "Content-Type: application/json" -X POST -d '{"dentifiers":["scix:2BZR-T8P9-CBXT","scix:2BBY-K9P2-229B"]}' http://localhost:4000
 
 and you should get back results from the Citation Helper.

--- a/citation_helper_service/citation_helper.py
+++ b/citation_helper_service/citation_helper.py
@@ -50,6 +50,17 @@ def get_suggestions(**args):
     if "Error"in meta_dict:
         return meta_dict
     # return results in required format
-    return [{'scix_id': x, 'score': y, 'title': meta_dict[x]['title'],
-             'author':meta_dict[x]['author']} for (x, y) in
-            paperFreq[:Nsuggestions] if x in meta_dict.keys()]
+    # Here we need to distinguish between whether the service received bibcodes
+    # or SciX IDs as input. Unless we convert bibcodes into SciX IDs in the very beginning
+    # (in the first case). In the future, we will be calling this service with just SciX IDs;
+    # at that point it will be less work to clean up this little conditional data processing
+    # than cleaning up all the logic to replace bibcodes by SciX IDs.
+    results = []
+    for p, s in paperFreq[:Nsuggestions]:
+        if p.startswith('scix:') and p in meta_dict:
+            results.append({'scix_id': p, 'score': s, 'title': meta_dict[p]['title'],
+             'author':meta_dict[p]['author']})
+        elif p in meta_dict:
+            results.append({'bibcode': p, 'score': s, 'title': meta_dict[p]['title'],
+             'author':meta_dict[p]['author']})
+    return results

--- a/citation_helper_service/citation_helper.py
+++ b/citation_helper_service/citation_helper.py
@@ -20,24 +20,24 @@ __all__ = ['get_suggestions']
 def get_suggestions(**args):
     # initializations
     papers = []
-    bibcodes = []
-    if 'bibcodes' in args:
-        bibcodes = args['bibcodes']
-    if len(bibcodes) == 0:
+    identifiers = []
+    if 'identifiers' in args:
+        identifiers = args['identifiers']
+    if len(identifiers) == 0:
         return []
     # Any overrides for default values?
     Nsuggestions = current_app.config.get('CITATION_HELPER_NUMBER_SUGGESTIONS')
     # get rid of potential trailing spaces
-    bibcodes = [a.strip() for a in bibcodes][
+    identifiers = [a.strip() for a in identifiers][
         :current_app.config.get('CITATION_HELPER_MAX_INPUT')]
     # start processing
     # get the citations for all publications (keeping multiplicity is
     # essential)
-    papers = get_data(bibcodes=bibcodes)
+    papers = get_data(identifiers=identifiers)
     if "Error" in papers:
         return papers
     # removes papers from the original list to get candidates
-    papers = [a for a in papers if a not in bibcodes]
+    papers = [a for a in papers if a not in identifiers]
     # establish frequencies of papers in results
     paperFreq = [(k, len(list(g))) for k, g in groupby(sorted(papers))]
     # and sort them, most frequent first
@@ -50,6 +50,6 @@ def get_suggestions(**args):
     if "Error"in meta_dict:
         return meta_dict
     # return results in required format
-    return [{'bibcode': x, 'score': y, 'title': meta_dict[x]['title'],
+    return [{'scix_id': x, 'score': y, 'title': meta_dict[x]['title'],
              'author':meta_dict[x]['author']} for (x, y) in
             paperFreq[:Nsuggestions] if x in meta_dict.keys()]

--- a/citation_helper_service/tests/README.md
+++ b/citation_helper_service/tests/README.md
@@ -1,0 +1,38 @@
+# Test data description
+In order to test the Citation Helper algorithm, the following synthetic data is used. The table below summarizes the data
+
+| Paper   |      Cites      |  isCitedBy |
+|----------|:-------------:|:------:|
+| a |  x, z | p|
+| b |    d,x   |   p,c |
+| c | e,y |    p,y,a |
+
+The algorithm accumulates all publications cited by and citing the origin papers, keeping track of multiplicity. Next it removes all the publications from the original list and only keeps those with a multiplicity of at least 2 (the "score"). The end result is the following list
+
+|Paper | Score |
+|------|:-----:|
+| p | 3 |
+| y | 2|
+| x | 2|
+
+In the test implementation, mock data consists of a list of entries like
+
+> {'id': '1', 'scix\_id': 'scix:a',
+>      'identifier':['a', 'scix:a'],
+>      'title': ['a_title'],
+>      'first_author':'a_author',
+>      'reference':['x', 'z'],
+>      'citation':['p']}
+
+The cited literature and citations in this mock data represent the data in the first table (above). This list of entries is returned as the mocked HTTP call to retrieve data from Solr. The `identifier` field in each of these entries contains both the paper identifier (read `bibcode`) and the associated SciX ID. The `title` and `first_author` entries are included to be used later to construct the final output. As a result, it should not matter whether the `reference` and `citation` fields contain bibcodes or SciX IDs, because to retrieve metadata, the `identifier` field is queried, which contains both.
+
+With the results calculated above, the code should return the following
+
+> {u'title': u'p_title', u'scix_id': u'scix:p', u'score': 3,
+>                      u'author': u'p_author et al.'},
+>                     {u'title': u'x_title', u'scix_id': u'scix:x',
+>                         u'score': 2, u'author': u'x_author et al.'},
+>                     {u'title': u'y_title', u'scix_id': u'scix:y', u'score': 2,
+>                      u'author': u'y_author et al.'}
+                     
+This output should get returned whether the microservices receives `['a','b','c']` as initial input, or `['scix:a','scix:b','scix:c']` (representing the SciX ID equivalents). The one difference is, which is covered by a unit test, that when bibcodes are submitted to the service, the output contains bibcodes (rather than SciX IDs). Otherwise the service would have to maintain a mapping between the bibcodes and SciX IDs being processed and have logic to convert bibcodes into SciX IDs, when encountered.

--- a/citation_helper_service/tests/test_endpoints.py
+++ b/citation_helper_service/tests/test_endpoints.py
@@ -9,45 +9,109 @@ from citation_helper_service import app
 import json
 import httpretty
 
+# mock data where references are represented by bibcode-like data
+# since we dealing with a bibcode scenario, the Solr docs are
+# assumed to have a 'bibcode' field (otherwise they would not participate
+# in this service to begin with)
 mockdata = [
-    {'id': '1', 'scix_id': 'a',
+    {'id': '1', 'scix_id': 'scix:a',
+     'bibcode':'a',
+     'identifier':['a', 'scix:a'],
      'title': ['a_title'],
      'first_author':'a_author',
      'reference':['x', 'z'],
      'citation':['p']},
-    {'id': '2', 'scix_id': 'b',
+    {'id': '2', 'scix_id': 'scix:b',
+     'bibcode':'b',
+     'identifier':['b', 'scix:b'],
      'title': ['b_title'],
      'first_author':'b_author',
      'reference':['d', 'x'],
      'citation':['p', 'c']},
-    {'id': '3', 'scix_id': 'c',
+    {'id': '3', 'scix_id': 'scix:c',
+     'bibcode':'c',
+     'identifier':['c', 'scix:c'],
      'title': ['c_title'],
      'first_author':'c_author',
      'reference':['e', 'y'],
      'citation':['p', 'y', 'a']},
-    {'id': '4', 'scix_id': 'x',
+    {'id': '4', 'scix_id': 'scix:x',
+     'bibcode':'x',
+     'identifier':['x', 'scix:x'],
      'title': ['x_title'],
      'first_author':'x_author',
      'reference':[],
      'citation':[]},
-    {'id': '5', 'scix_id': 'y',
+    {'id': '5', 'scix_id': 'scix:y',
+     'bibcode':'y',
+     'identifier':['y', 'scix:y'],
      'title': ['y_title'],
      'first_author':'y_author',
      'reference':[],
      'citation':[]},
     {'id': '6',
-     'scix_id': 'z',
+     'identifier':['z', 'scix:z'],
+     'bibcode':'z',
+     'scix_id': 'scix:z',
      'title': ['z_title'],
      'first_author':'z_author',
      'reference':[],
      'citation':[]},
-    {'id': '7', 'scix_id': 'p',
+    {'id': '7', 'scix_id': 'scix:p',
+     'identifier':['p', 'scix:p'],
+     'bibcode':'p',
      'title': ['p_title'],
      'first_author':'p_author',
      'reference':[],
      'citation':[]}
 ]
 
+# mock data where references are represented by scix-like data
+mockdata_scix = [
+    {'id': '1', 'scix_id': 'scix:a',
+     'identifier':['a', 'scix:a'],
+     'title': ['a_title'],
+     'first_author':'a_author',
+     'reference':['scix:x', 'scix:z'],
+     'citation':['scix:p']},
+    {'id': '2', 'scix_id': 'scix:b',
+     'identifier':['b', 'scix:b'],
+     'title': ['b_title'],
+     'first_author':'b_author',
+     'reference':['scix:d', 'scix:x'],
+     'citation':['scix:p', 'scix:c']},
+    {'id': '3', 'scix_id': 'scix:c',
+     'identifier':['c', 'scix:c'],
+     'title': ['c_title'],
+     'first_author':'c_author',
+     'reference':['scix:e', 'scix:y'],
+     'citation':['scix:p', 'scix:y', 'scix:a']},
+    {'id': '4', 'scix_id': 'scix:x',
+     'identifier':['x', 'scix:x'],
+     'title': ['x_title'],
+     'first_author':'x_author',
+     'reference':[],
+     'citation':[]},
+    {'id': '5', 'scix_id': 'scix:y',
+     'identifier':['y', 'scix:y'],
+     'title': ['y_title'],
+     'first_author':'y_author',
+     'reference':[],
+     'citation':[]},
+    {'id': '6',
+     'identifier':['z', 'scix:z'],
+     'scix_id': 'scix:z',
+     'title': ['z_title'],
+     'first_author':'z_author',
+     'reference':[],
+     'citation':[]},
+    {'id': '7', 'scix_id': 'scix:p',
+     'identifier':['p', 'scix:p'],
+     'title': ['p_title'],
+     'first_author':'p_author',
+     'reference':[],
+     'citation':[]}
+]
 
 class TestBadRequests(TestCase):
 
@@ -92,8 +156,43 @@ class TestGoodRequests(TestCase):
         return app_
 
     @httpretty.activate
-    def test_service_results(self):
+    def test_service_results_scixid(self):
         '''Test to see if mock data produces expected results'''
+        # In this version the references/citations are stored in SciX ID-like format
+        httpretty.register_uri(
+            httpretty.GET, self.app.config.get(
+                'CITATION_HELPER_SOLR_PATH'),
+            content_type='application/json',
+            status=200,
+            body="""{
+            "responseHeader":{
+            "status":0, "QTime":0,
+            "params":{ "fl":"reference,citation", "indent":"true",
+            "wt":"json", "q":"*"}},
+            "response":{"numFound":10456930,"start":0,"docs":%s
+            }}""" % json.dumps(mockdata_scix))
+
+        expected = [{u'title': u'p_title', u'scix_id': u'scix:p', u'score': 3,
+                     u'author': u'p_author et al.'},
+                    {u'title': u'x_title', u'scix_id': u'scix:x',
+                        u'score': 2, u'author': u'x_author et al.'},
+                    {u'title': u'y_title', u'scix_id': u'scix:y', u'score': 2,
+                     u'author': u'y_author et al.'}]
+
+        identifiers = ['scix:a', 'scix:b', 'scix:c']
+
+        r = self.client.post(
+            url_for('citationhelper'),
+            content_type='application/json',
+            data=json.dumps({'identifiers': identifiers}))
+
+        self.assertTrue(r.status_code == 200)
+        self.assertEqual(expected, r.json)
+
+    @httpretty.activate
+    def test_service_results_bibc(self):
+        '''Test to see if mock data produces expected results'''
+        # In this version the references/citations are stored in bibcode-like format
         httpretty.register_uri(
             httpretty.GET, self.app.config.get(
                 'CITATION_HELPER_SOLR_PATH'),
@@ -107,11 +206,11 @@ class TestGoodRequests(TestCase):
             "response":{"numFound":10456930,"start":0,"docs":%s
             }}""" % json.dumps(mockdata))
 
-        expected = [{u'title': u'p_title', u'scix_id': u'p', u'score': 3,
+        expected = [{u'title': u'p_title', u'bibcode': u'p', u'score': 3,
                      u'author': u'p_author et al.'},
-                    {u'title': u'x_title', u'scix_id': u'x',
+                    {u'title': u'x_title', u'bibcode': u'x',
                         u'score': 2, u'author': u'x_author et al.'},
-                    {u'title': u'y_title', u'scix_id': u'y', u'score': 2,
+                    {u'title': u'y_title', u'bibcode': u'y', u'score': 2,
                      u'author': u'y_author et al.'}]
 
         identifiers = ['a', 'b', 'c']
@@ -123,7 +222,6 @@ class TestGoodRequests(TestCase):
 
         self.assertTrue(r.status_code == 200)
         self.assertEqual(expected, r.json)
-
 
 class TestSolrError(TestCase):
 
@@ -159,7 +257,7 @@ class TestSolrError(TestCase):
 
         self.assertTrue(r.status_code == 200)
         self.assertTrue('Error' in r.json)
-        self.assertTrue('Unable to get results' in r.json.get('Error'))
+        self.assertTrue('Unable to get citation lists!' in r.json.get('Error'))
 
 
 class TestNoRequests(TestCase):

--- a/citation_helper_service/tests/test_endpoints.py
+++ b/citation_helper_service/tests/test_endpoints.py
@@ -10,38 +10,38 @@ import json
 import httpretty
 
 mockdata = [
-    {'id': '1', 'bibcode': 'a',
+    {'id': '1', 'scix_id': 'a',
      'title': ['a_title'],
      'first_author':'a_author',
      'reference':['x', 'z'],
      'citation':['p']},
-    {'id': '2', 'bibcode': 'b',
+    {'id': '2', 'scix_id': 'b',
      'title': ['b_title'],
      'first_author':'b_author',
      'reference':['d', 'x'],
      'citation':['p', 'c']},
-    {'id': '3', 'bibcode': 'c',
+    {'id': '3', 'scix_id': 'c',
      'title': ['c_title'],
      'first_author':'c_author',
      'reference':['e', 'y'],
      'citation':['p', 'y', 'a']},
-    {'id': '4', 'bibcode': 'x',
+    {'id': '4', 'scix_id': 'x',
      'title': ['x_title'],
      'first_author':'x_author',
      'reference':[],
      'citation':[]},
-    {'id': '5', 'bibcode': 'y',
+    {'id': '5', 'scix_id': 'y',
      'title': ['y_title'],
      'first_author':'y_author',
      'reference':[],
      'citation':[]},
     {'id': '6',
-     'bibcode': 'z',
+     'scix_id': 'z',
      'title': ['z_title'],
      'first_author':'z_author',
      'reference':[],
      'citation':[]},
-    {'id': '7', 'bibcode': 'p',
+    {'id': '7', 'scix_id': 'p',
      'title': ['p_title'],
      'first_author':'p_author',
      'reference':[],
@@ -51,7 +51,7 @@ mockdata = [
 
 class TestBadRequests(TestCase):
 
-    '''Tests that no or too many submitted bibcodes result
+    '''Tests that no or too many submitted identifiers result
        in the proper responses'''
 
     def create_app(self):
@@ -60,23 +60,23 @@ class TestBadRequests(TestCase):
         return app_
 
     def testNoBibcodesSubmitted(self):
-        '''When no input bibcodes are submitted an error should be raised'''
+        '''When no input identifiers are submitted an error should be raised'''
         r = self.client.post(
             url_for('citationhelper'),
-            data=dict(bibcodes=[]))
+            data=dict(identifiers=[]))
         self.assertTrue(r.status_code == 200)
         self.assertTrue('Error' in r.json)
         self.assertTrue(r.json.get('Error') == 'Unable to get results!')
 
     def testTooManyBibcodes(self):
-        '''When more than the maximum input bibcodes are submitted an error
+        '''When more than the maximum input identifiers are submitted an error
            should be raised'''
-        bibcodes = ["bibcode"] * \
+        identifiers = ["scix_id"] * \
             (self.app.config.get('CITATION_HELPER_MAX_SUBMITTED') + 1)
         r = self.client.post(
             url_for('citationhelper'),
             content_type='application/json',
-            data=json.dumps({'bibcodes': bibcodes}))
+            data=json.dumps({'identifiers': identifiers}))
         self.assertTrue(r.status_code == 200)
         self.assertTrue('Error' in r.json)
         self.assertTrue(r.json.get('Error') == 'Unable to get results!')
@@ -107,19 +107,19 @@ class TestGoodRequests(TestCase):
             "response":{"numFound":10456930,"start":0,"docs":%s
             }}""" % json.dumps(mockdata))
 
-        expected = [{u'title': u'p_title', u'bibcode': u'p', u'score': 3,
+        expected = [{u'title': u'p_title', u'scix_id': u'p', u'score': 3,
                      u'author': u'p_author et al.'},
-                    {u'title': u'x_title', u'bibcode': u'x',
+                    {u'title': u'x_title', u'scix_id': u'x',
                         u'score': 2, u'author': u'x_author et al.'},
-                    {u'title': u'y_title', u'bibcode': u'y', u'score': 2,
+                    {u'title': u'y_title', u'scix_id': u'y', u'score': 2,
                      u'author': u'y_author et al.'}]
 
-        bibcodes = ['a', 'b', 'c']
+        identifiers = ['a', 'b', 'c']
 
         r = self.client.post(
             url_for('citationhelper'),
             content_type='application/json',
-            data=json.dumps({'bibcodes': bibcodes}))
+            data=json.dumps({'identifiers': identifiers}))
 
         self.assertTrue(r.status_code == 200)
         self.assertEqual(expected, r.json)
@@ -150,12 +150,12 @@ class TestSolrError(TestCase):
             "response":{"numFound":10456930,"start":0,"docs":[]
             }}""")
 
-        bibcodes = ['a', 'b', 'c']
+        identifiers = ['a', 'b', 'c']
 
         r = self.client.post(
             url_for('citationhelper'),
             content_type='application/json',
-            data=json.dumps({'bibcodes': bibcodes}))
+            data=json.dumps({'identifiers': identifiers}))
 
         self.assertTrue(r.status_code == 200)
         self.assertTrue('Error' in r.json)
@@ -187,12 +187,12 @@ class TestNoRequests(TestCase):
             "response":{"numFound":0,"start":0,"docs":[]
             }}""")
 
-        bibcodes = ['a', 'b', 'c']
+        identifiers = ['a', 'b', 'c']
 
         r = self.client.post(
             url_for('citationhelper'),
             content_type='application/json',
-            data=json.dumps({'bibcodes': bibcodes}))
+            data=json.dumps({'identifiers': identifiers}))
 
         self.assertTrue(r.status_code == 200)
         self.assertTrue('Error' in r.json)

--- a/citation_helper_service/tests/test_internals.py
+++ b/citation_helper_service/tests/test_internals.py
@@ -13,38 +13,38 @@ from citation_helper_service.utils import get_meta_data
 from citation_helper_service.utils import chunks
 
 mockdata = [
-    {'id': '1', 'bibcode': 'a',
+    {'id': '1', 'scix_id': 'a',
      'title': ['a_title'],
      'first_author':'a_author',
      'reference':['x', 'z'],
      'citation':['p']},
-    {'id': '2', 'bibcode': 'b',
+    {'id': '2', 'scix_id': 'b',
      'title': ['b_title'],
      'first_author':'b_author',
      'reference':['d', 'x'],
      'citation':['p', 'c']},
-    {'id': '3', 'bibcode': 'c',
+    {'id': '3', 'scix_id': 'c',
      'title': ['c_title'],
      'first_author':'c_author',
      'reference':['e', 'y'],
      'citation':['p', 'y', 'a']},
-    {'id': '4', 'bibcode': 'x',
+    {'id': '4', 'scix_id': 'x',
      'title': ['x_title'],
      'first_author':'x_author',
      'reference':[],
      'citation':[]},
-    {'id': '5', 'bibcode': 'y',
+    {'id': '5', 'scix_id': 'y',
      'title': ['y_title'],
      'first_author':'y_author',
      'reference':[],
      'citation':[]},
     {'id': '6',
-     'bibcode': 'z',
+     'scix_id': 'z',
      'title': ['z_title'],
      'first_author':'z_author',
      'reference':[],
      'citation':[]},
-    {'id': '7', 'bibcode': 'p',
+    {'id': '7', 'scix_id': 'p',
      'title': ['p_title'],
      'first_author':'p_author',
      'reference':[],
@@ -103,8 +103,8 @@ class TestMethods(TestCase):
         expected_papers = [
             u'x', u'z', u'd', u'x', u'e', u'y', u'p',
             u'p', u'c', u'p', u'y', u'a']
-        bibcodes = ['a', 'b', 'c']
-        results = get_data(bibcodes=bibcodes)
+        identifiers = ['a', 'b', 'c']
+        results = get_data(identifiers=identifiers)
         self.assertEqual(results, expected_papers)
 
         expected_meta = {u'a': {'author': u'a_author et al.', 'title': u'a_title'},

--- a/citation_helper_service/utils.py
+++ b/citation_helper_service/utils.py
@@ -19,22 +19,22 @@ from .client import Client
 
 def get_data(**args):
     """
-    Get the references for a set of bibcodes
+    Get the references for a set of identifiers
     """
     references = []
     citations = []
     # This information can be retrieved with one single Solr query
-    # (just an 'OR' query of a list of bibcodes)
+    # (just an 'OR' query of a list of identifiers)
     # To restrict the size of the query URL, we split the list of
-    # bibcodes up in a list of smaller lists
-    biblists = list(
-        chunks(args['bibcodes'],
+    # identifiers up in a list of smaller lists
+    idlists = list(
+        chunks(args['identifiers'],
                current_app.config.get('CITATION_HELPER_CHUNK_SIZE')))
-    for biblist in biblists:
-        q = " OR ".join(["bibcode:%s" % a for a in biblist])
+    for idlist in idlists:
+        q = " OR ".join(["identifier:%s" % a for a in idlist])
         # Get the information from Solr
         # We only need the contents of the 'reference' field (i.e. the
-        # list of bibcodes referenced by the paper at hand)
+        # list of identifiers referenced by the paper at hand)
         params = {'wt': 'json', 'q': q, 'fl': 'reference,citation',
                   'rows': current_app.config['CITATION_HELPER_MAX_HITS']}
         response = Client(config=current_app.config).get(
@@ -45,27 +45,27 @@ def get_data(**args):
                     "Error Info": "Solr response: %s" % str(response.text),
                     "Status Code": response.status_code}
         resp = response.json()
-        # Collect all bibcodes in a list (do NOT remove multiplicity)
+        # Collect all identifiers in a list (do NOT remove multiplicity)
         for doc in resp['response']['docs']:
             if 'reference' in doc:
                 references += doc['reference']
             if 'citation' in doc:
                 citations += doc['citation']
-    return [bib for bib in references + citations]
+    return [identifier for identifier in references + citations]
 
 
 def get_meta_data(**args):
     """
-    Get the meta data for a set of bibcodes
+    Get the meta data for a set of identifiers
     """
     data_dict = {}
     # This information can be retrieved with one single Solr query
-    # (just an 'OR' query of a list of bibcodes)
-    bibcodes = [bibcode for (bibcode, score) in args['results']]
-    list = " OR ".join(["bibcode:%s" % a for a in bibcodes])
+    # (just an 'OR' query of a list of identifiers)
+    identifiers = [identifier for (identifier, score) in args['results']]
+    list = " OR ".join(["identifier:%s" % a for a in identifiers])
     q = '%s' % list
     # Get the information from Solr
-    params = {'wt': 'json', 'q': q, 'fl': 'bibcode,title,first_author',
+    params = {'wt': 'json', 'q': q, 'fl': 'scix_id,title,first_author',
               'rows': current_app.config.get('CITATION_HELPER_MAX_HITS')}
     response = Client(config=current_app.config).get(
         current_app.config.get('CITATION_HELPER_SOLR_PATH'), params=params
@@ -83,7 +83,7 @@ def get_meta_data(**args):
         author = 'NA'
         if 'first_author' in doc:
             author = "%s et al." % doc['first_author']
-        data_dict[doc['bibcode']] = {'title': title, 'author': author}
+        data_dict[doc['scix_id']] = {'title': title, 'author': author}
     return data_dict
 
 

--- a/citation_helper_service/utils.py
+++ b/citation_helper_service/utils.py
@@ -31,7 +31,7 @@ def get_data(**args):
         chunks(args['identifiers'],
                current_app.config.get('CITATION_HELPER_CHUNK_SIZE')))
     for idlist in idlists:
-        q = " OR ".join(["identifier:%s" % a for a in idlist])
+        q = " OR ".join(['identifier:"%s"' % a for a in idlist])
         # Get the information from Solr
         # We only need the contents of the 'reference' field (i.e. the
         # list of identifiers referenced by the paper at hand)
@@ -41,7 +41,7 @@ def get_data(**args):
             current_app.config.get('CITATION_HELPER_SOLR_PATH'),
             params=params)
         if response.status_code != 200:
-            return {"Error": "Unable to get results!",
+            return {"Error": "Unable to get citation lists!",
                     "Error Info": "Solr response: %s" % str(response.text),
                     "Status Code": response.status_code}
         resp = response.json()
@@ -62,20 +62,22 @@ def get_meta_data(**args):
     # This information can be retrieved with one single Solr query
     # (just an 'OR' query of a list of identifiers)
     identifiers = [identifier for (identifier, score) in args['results']]
-    list = " OR ".join(["identifier:%s" % a for a in identifiers])
-    q = '%s' % list
+    qlist = " OR ".join(['identifier:"%s"' % a for a in identifiers])
+    q = '%s' % qlist
     # Get the information from Solr
-    params = {'wt': 'json', 'q': q, 'fl': 'scix_id,title,first_author',
+    params = {'wt': 'json', 'q': q, 'fl': 'scix_id,bibcode,title,first_author',
               'rows': current_app.config.get('CITATION_HELPER_MAX_HITS')}
     response = Client(config=current_app.config).get(
         current_app.config.get('CITATION_HELPER_SOLR_PATH'), params=params
         )
     if response.status_code != 200:
-        return {"Error": "Unable to get results!",
+        return {"Error": "Unable to get metadata!",
                 "Error Info": response.text,
                 "Status Code": response.status_code}
     resp = response.json()
     # Collect meta data
+    # The logic to add a "bibcode" entry in there is to support
+    # the cases where the service is called with bibcodes
     for doc in resp['response']['docs']:
         title = 'NA'
         if 'title' in doc:
@@ -83,9 +85,13 @@ def get_meta_data(**args):
         author = 'NA'
         if 'first_author' in doc:
             author = "%s et al." % doc['first_author']
+        bibcode = 'NA'
+        if 'bibcode' in doc:
+            bibcode = doc['bibcode']
         data_dict[doc['scix_id']] = {'title': title, 'author': author}
+        if bibcode != 'NA':
+            data_dict[bibcode] = {'title': title, 'author': author}
     return data_dict
-
 
 def chunks(l, n):
     """

--- a/citation_helper_service/views.py
+++ b/citation_helper_service/views.py
@@ -21,7 +21,11 @@ class CitationHelper(Resource):
             current_app.logger.error('No identifiers were provided to Citation Helper')
             return {'Error': 'Unable to get results!',
                     'Error Info': 'No identifiers found in POST body'}, 200
-        identifiers = list(map(str, request.json['identifiers']))
+        # For backward compatibility, we check for both 'identifiers' and 'bibcodes' in the payload
+        try:
+            identifiers = request.json.get('identifiers',[]) + request.json.get('bibcodes',[])
+        except:
+            identifiers = []
         if len(identifiers) > \
                 current_app.config.get('CITATION_HELPER_MAX_SUBMITTED'):
             current_app.logger.warning('Citation Helper called with %s identifiers. Maximum is: %s!'%(len(identifiers),current_app.config.get('CITATION_HELPER_MAX_SUBMITTED')))
@@ -30,6 +34,7 @@ class CitationHelper(Resource):
                     'Number of submitted identifiers exceeds maximum number'}, 200
 
         results = get_suggestions(identifiers=identifiers)
+
         if "Error" in results:
             msg = 'Citation Helper request request blew up'
             if 'Error Info' in results:

--- a/citation_helper_service/views.py
+++ b/citation_helper_service/views.py
@@ -17,19 +17,19 @@ class CitationHelper(Resource):
 
     def post(self):
         stime = time.time()
-        if not request.json or 'bibcodes' not in request.json:
-            current_app.logger.error('No bibcodes were provided to Citation Helper')
+        if not request.json or 'identifiers' not in request.json:
+            current_app.logger.error('No identifiers were provided to Citation Helper')
             return {'Error': 'Unable to get results!',
-                    'Error Info': 'No bibcodes found in POST body'}, 200
-        bibcodes = list(map(str, request.json['bibcodes']))
-        if len(bibcodes) > \
+                    'Error Info': 'No identifiers found in POST body'}, 200
+        identifiers = list(map(str, request.json['identifiers']))
+        if len(identifiers) > \
                 current_app.config.get('CITATION_HELPER_MAX_SUBMITTED'):
-            current_app.logger.warning('Citation Helper called with %s bibcodes. Maximum is: %s!'%(len(bibcodes),current_app.config.get('CITATION_HELPER_MAX_SUBMITTED')))
+            current_app.logger.warning('Citation Helper called with %s identifiers. Maximum is: %s!'%(len(identifiers),current_app.config.get('CITATION_HELPER_MAX_SUBMITTED')))
             return {'Error': 'Unable to get results!',
                     'Error Info':
-                    'Number of submitted bibcodes exceeds maximum number'}, 200
+                    'Number of submitted identifiers exceeds maximum number'}, 200
 
-        results = get_suggestions(bibcodes=bibcodes)
+        results = get_suggestions(identifiers=identifiers)
         if "Error" in results:
             msg = 'Citation Helper request request blew up'
             if 'Error Info' in results:

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ CITATION_HELPER_MAX_INPUT = 500
 # Maximum number allowed in submitted bibcodes
 CITATION_HELPER_MAX_SUBMITTED = 100
 # Bibcode input list will be split into chunks of this size
-CITATION_HELPER_CHUNK_SIZE = 100
+CITATION_HELPER_CHUNK_SIZE = 20
 # The maximum number of suggestions returned by the service
 CITATION_HELPER_NUMBER_SUGGESTIONS = 10
 # Minimal score for papers to be included in results


### PR DESCRIPTION
This PR represents support of the SciX ID in the `citation_helper` service. Backwards compatibility it also supported. This is accomplished by still supporting `bibcodes` as field in the POST payload to submit bibcodes, together with the new field `identifiers` (envisioned to hold SciX IDs, but only from a conceptual point of view, since SciX IDs could theoretically also be submitted using the `bibcodes` field).

The unit tests have been extended to test for both input scenarios. To this end synthetic mock data has been used (rather than actual Solr records); a README has been included in the test directory explaining the details behind the data and the tests.

Note that a fundamentally different approach could have been taken: detect whether bibcodes have been submitted to the service and convert them to SciX IDs. While this approach can be supported without additional API calls, it does require more elaborate code updates than the ones currently implemented.

Also note that the exact format of the entries in the `reference` and `citation` fields in Solr (bibcodes or SciX IDs) is irrelevant for the workings of this service; when metadata is retrieved from Solr for these identifiers, when included in the output, the query makes use of the `identifier` field, which contains both.